### PR TITLE
Inherit from Dask Dataframe classes

### DIFF
--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -962,3 +962,9 @@ def make_meta_dataframe(x):
 @dd.core.make_meta.register(gd.index.Index)
 def make_meta_index(x):
     return x[:0]
+
+
+@dd.methods.concat.register((gd.DataFrame, gd.Series, gd.Index))
+def concat_pygdf(*dfs, ignore_index=False, **kwargs):
+    # TODO: silently ignoring other kwargs
+    return gd.concat(dfs, ignore_index=ignore_index)

--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -1,4 +1,3 @@
-import operator
 from uuid import uuid4
 from math import ceil
 from collections import OrderedDict
@@ -10,7 +9,7 @@ from libgdf_cffi import libgdf
 from toolz import merge, partition_all
 
 import dask.dataframe as dd
-from dask.base import tokenize, normalize_token, DaskMethodsMixin
+from dask.base import tokenize, normalize_token
 from dask.context import _globals
 from dask.core import flatten
 from dask.compatibility import apply
@@ -19,10 +18,11 @@ from dask.threaded import get as threaded_get
 from dask.utils import funcname, M, OperatorMethodMixin
 from dask.dataframe.utils import raise_on_meta_error
 from dask.dataframe.core import Scalar
+from dask.dataframe import from_delayed
 from dask.delayed import delayed
 from dask import compute
 
-from .utils import make_meta, check_meta
+from .utils import make_meta
 from . import batcher_sortnet
 from .accessor import DatetimeAccessor
 
@@ -756,9 +756,6 @@ def _from_pandas(df):
     return gd.DataFrame.from_pandas(df)
 
 
-from dask.dataframe import from_delayed
-
-
 def from_dask_dataframe(df):
     """Create a `dask_gdf.DataFrame` from a `dask.dataframe.DataFrame`
 
@@ -939,6 +936,7 @@ dd.core.parallel_types.extend([
     (gd.index.Index, Index),
 ])
 
+
 @dd.core.meta_nonempty.register(gd.Series)
 def meta_nonempty_series(x):
     s = dd.core.meta_nonempty(x.to_pandas())
@@ -949,7 +947,7 @@ def meta_nonempty_series(x):
 
 
 @dd.core.meta_nonempty.register(gd.DataFrame)
-def meta_nonempty_series(x):
+def meta_nonempty_dataframe(x):
     df = dd.core.meta_nonempty(x.to_pandas())
     return gd.DataFrame.from_pandas(df)
 

--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -931,17 +931,17 @@ def reduction(args, chunk=None, aggregate=None, combine=None,
 
 
 @dd.core.get_parallel_type.register(gd.DataFrame)
-def _(_):
+def get_parallel_type_dataframe(_):
     return DataFrame
 
 
 @dd.core.get_parallel_type.register(gd.Series)
-def _(_):
+def get_parallel_type_series(_):
     return Series
 
 
 @dd.core.get_parallel_type.register(gd.Index)
-def _(_):
+def get_parallel_type_index(_):
     return Index
 
 

--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -930,11 +930,19 @@ def reduction(args, chunk=None, aggregate=None, combine=None,
     return dd.core.new_dd_object(dsk, b, meta, (None, None))
 
 
-dd.core.parallel_types.extend([
-    (gd.Series, Series),
-    (gd.DataFrame, DataFrame),
-    (gd.index.Index, Index),
-])
+@dd.core.get_parallel_type.register(gd.DataFrame)
+def _(_):
+    return DataFrame
+
+
+@dd.core.get_parallel_type.register(gd.Series)
+def _(_):
+    return Series
+
+
+@dd.core.get_parallel_type.register(gd.Index)
+def _(_):
+    return Index
 
 
 @dd.core.meta_nonempty.register(gd.Series)
@@ -962,7 +970,7 @@ def make_meta_index(x):
     return x[:0]
 
 
-@dd.methods.concat.register((gd.DataFrame, gd.Series, gd.Index))
-def concat_pygdf(*dfs, ignore_index=False, **kwargs):
+@dd.methods.concat_dispatch.register((gd.DataFrame, gd.Series, gd.Index))
+def concat_pygdf(dfs, ignore_index=False, **kwargs):
     # TODO: silently ignoring other kwargs
     return gd.concat(dfs, ignore_index=ignore_index)

--- a/dask_gdf/tests/test_delayed_io.py
+++ b/dask_gdf/tests/test_delayed_io.py
@@ -163,6 +163,4 @@ def test_frame_dtype_error():
     with pytest.raises(ValueError) as raises:
         combined.compute()
 
-    # print("out")
-    # raises.match(r"^Metadata mismatch found in `from_delayed`.")
-    # raises.match(r"\s+\|\s+".join(['bad', 'float32', 'float64']))
+    raises.match(r"same type")

--- a/dask_gdf/tests/test_delayed_io.py
+++ b/dask_gdf/tests/test_delayed_io.py
@@ -141,7 +141,7 @@ def test_frame_extra_columns_error():
         combined.compute()
 
     raises.match(r"^Metadata mismatch found in `from_delayed`.")
-    raises.match(r"extra columns")
+    raises.match(r"z")
 
 
 def test_frame_dtype_error():
@@ -163,6 +163,6 @@ def test_frame_dtype_error():
     with pytest.raises(ValueError) as raises:
         combined.compute()
 
-    print("out")
-    raises.match(r"^Metadata mismatch found in `from_delayed`.")
-    raises.match(r"\s+\|\s+".join(['bad', 'float32', 'float64']))
+    # print("out")
+    # raises.match(r"^Metadata mismatch found in `from_delayed`.")
+    # raises.match(r"\s+\|\s+".join(['bad', 'float32', 'float64']))

--- a/dask_gdf/tests/test_reductions.py
+++ b/dask_gdf/tests/test_reductions.py
@@ -5,6 +5,8 @@ import pytest
 import pygdf as gd
 import dask_gdf as dgd
 
+from dask.dataframe.utils import assert_eq
+
 
 def _make_random_frame(nelem, npartitions=2):
     df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
@@ -41,4 +43,5 @@ def test_series_reduce(reducer):
 
     got = reducer(gdf.x)
     exp = reducer(df.x)
-    np.testing.assert_array_almost_equal(got.compute(scheduler='single-threaded'), exp)
+
+    assert_eq(got, exp)

--- a/dask_gdf/tests/test_reductions.py
+++ b/dask_gdf/tests/test_reductions.py
@@ -41,4 +41,4 @@ def test_series_reduce(reducer):
 
     got = reducer(gdf.x)
     exp = reducer(df.x)
-    np.testing.assert_array_almost_equal(got.compute(), exp)
+    np.testing.assert_array_almost_equal(got.compute(scheduler='single-threaded'), exp)

--- a/dask_gdf/tests/test_series.py
+++ b/dask_gdf/tests/test_series.py
@@ -1,0 +1,45 @@
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pygdf as gd
+import dask_gdf as dgd
+import dask.dataframe as dd
+from dask.dataframe.utils import assert_eq
+
+
+def _make_random_frame(nelem, npartitions=2):
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
+                       'y': np.random.normal(size=nelem) + 1})
+    gf = gd.DataFrame.from_pandas(df)
+    return df, gf
+
+
+_reducers = [
+    'sum',
+    'count',
+    'mean',
+    'var',
+    'std',
+    'min',
+    'max',
+]
+
+
+@pytest.mark.parametrize('func', [
+    lambda x: x,
+    lambda x: x.nlargest(2),
+    lambda x: x.nsmallest(2),
+    lambda x: x + 1,
+    lambda x: x * 2,
+    lambda x: x ** 2,
+])
+def test_series_reduce(func):
+    df, gf = _make_random_frame(20)
+    ddf = dd.from_pandas(df, npartitions=3)
+    gdf = dgd.from_pygdf(gf, npartitions=3)
+
+    a = func(ddf.x)
+    b = func(gdf.x)
+    assert_eq(a, b)


### PR DESCRIPTION
This allows us to remove a large amount of boilerplate code.

This requires changes upstream both in Dask DataFrame to enable better
subclassing and in PyGDF to better match the Pandas API.