### PR TITLE
Add basic read_csv implementation

### DIFF
--- a/dask_cudf/__init__.py
+++ b/dask_cudf/__init__.py
@@ -6,6 +6,7 @@ from .core import (
     concat,
     from_delayed,
 )
+from .io import read_csv
 
 from cudf._version import get_versions
 

--- a/dask_cudf/io/__init__.py
+++ b/dask_cudf/io/__init__.py
@@ -1,0 +1,1 @@
+from .csv import read_csv

--- a/dask_cudf/io/csv.py
+++ b/dask_cudf/io/csv.py
@@ -1,0 +1,22 @@
+from glob import glob
+
+import cudf
+from dask.base import tokenize
+from dask.compatibility import apply
+import dask.dataframe as dd
+
+
+def read_csv(path, **kwargs):
+    filenames = sorted(glob(str(path)))  # TODO: lots of complexity
+    name = "read-csv-" + tokenize(path, **kwargs)  # TODO: get last modified time
+
+    meta = cudf.read_csv(filenames[0], **kwargs)
+
+    graph = {
+        (name, i): (apply, cudf.read_csv, [fn], kwargs)
+        for i, fn in enumerate(filenames)
+    }
+
+    divisions = [None] * (len(filenames) + 1)
+
+    return dd.core.new_dd_object(graph, name, meta, divisions)

--- a/dask_cudf/io/tests/test_csv.py
+++ b/dask_cudf/io/tests/test_csv.py
@@ -1,0 +1,13 @@
+import dask
+import dask_cudf
+import dask.dataframe as dd
+
+
+def test_read_csv(tmp_path):
+    df = dask.datasets.timeseries(dtypes={"x": int, "y": int}, freq="120s").reset_index(
+        drop=True
+    )
+    df.to_csv(tmp_path / "data-*.csv", index=False)
+
+    df2 = dask_cudf.read_csv(tmp_path / "*.csv")
+    dd.assert_eq(df, df2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag_prefix =
 parentdir_prefix = dask_cudf-
 
 [flake8]
-exclude = docs
+exclude = docs, __init__.py
 max-line-length = 88
 ignore =
     # Assigning lambda expression


### PR DESCRIPTION
This doesn't chunk files.  It doesn't work with non-local storage.  It doesn't unify dtypes.  It just calls `cudf.read_csv` a bunch on the arguments.

Still, it's fun to play with.