### PR TITLE
Remove assertions outlawing inner joins

### DIFF
--- a/dask_cudf/core.py
+++ b/dask_cudf/core.py
@@ -247,7 +247,6 @@ class DataFrame(_Frame, dd.core.DataFrame):
     def merge(self, other, on=None, how="left", lsuffix="_x", rsuffix="_y"):
         """Merging two dataframes on the column(s) indicated in *on*.
         """
-        assert how == "left", "left join is impelemented"
         if on is None:
             return self.join(other, how=how, lsuffix=lsuffix, rsuffix=rsuffix)
         else:
@@ -314,10 +313,10 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
             for k, dtype in rhs_dtypes:
                 data = np.zeros(len(lhs), dtype=dtype)
-                mask_size = cudf.utils.calc_chunk_size(
-                    data.size, cudf.utils.mask_bitsize
+                mask_size = cudf.utils.utils.calc_chunk_size(
+                    data.size, cudf.utils.utils.mask_bitsize
                 )
-                mask = np.zeros(mask_size, dtype=cudf.utils.mask_dtype)
+                mask = np.zeros(mask_size, dtype=cudf.utils.utils.mask_dtype)
                 sr = cudf.Series.from_masked_array(
                     data=data, mask=mask, null_count=data.size
                 )

--- a/dask_cudf/join_impl.py
+++ b/dask_cudf/join_impl.py
@@ -50,7 +50,6 @@ def join_frames(left, right, on, how, lsuffix, rsuffix):
     lsuffix, rsuffix : str
 
     """
-    assert how == "left"
 
     def fix_left(df):
         newdf = cudf.DataFrame()
@@ -77,20 +76,7 @@ def join_frames(left, right, on, how, lsuffix, rsuffix):
     )
 
     def merge(left, right):
-        if left is None and right is None:
-            # FIXME: this should go inside cudf so it can merge two empty
-            #        frames
-            return empty_frame
-        elif left is None:
-            # FIXME: this should go inside cudf so it can merge empty frames
-            #        left frames
-            return empty_frame
-        elif right is None:
-            # FIXME: this should go inside cudf so it can merge empty frames
-            #        right frames
-            return fix_left(left)
-        else:
-            return left.merge(right, on=on, how=how, lsuffix=lsuffix, rsuffix=rsuffix)
+        return left.merge(right, on=on, how=how, lsuffix=lsuffix, rsuffix=rsuffix)
 
     left_val_names = [k for k in left.columns if k not in on]
     right_val_names = [k for k in right.columns if k not in on]


### PR DESCRIPTION
These seem to work ok, at least with a simple example.
My guess is that other cleanups and removal of special-case code removed
whatever issue they were protecting against.

This could use a stronger test suite, but I'd like to handle that for
all joins at once, probably after some other cleanup is done.

The only truely relevant part of this PR is removing the assert statements.  While I was at it I removed some other special-case code that had been hanging around for a while.

cc @randerzander 

Fixes #82 