### PR TITLE
Increase default chunk size in read_csv

### DIFF
--- a/dask_cudf/io/csv.py
+++ b/dask_cudf/io/csv.py
@@ -8,7 +8,7 @@ import dask.dataframe as dd
 from dask.utils import parse_bytes
 
 
-def read_csv(path, chunksize="128 MiB", **kwargs):
+def read_csv(path, chunksize="256 MiB", **kwargs):
     if isinstance(chunksize, str):
         chunksize = parse_bytes(chunksize)
     filenames = sorted(glob(str(path)))  # TODO: lots of complexity


### PR DESCRIPTION
Benchmark from @randerzander 

```
ChunkSize: 128: Time: 61.621484994888306, Data Size: 22.28 GB
ChunkSize: 256: Time: 51.05866718292236, Data Size: 22.28 GB
ChunkSize: 512: Time: 53.659711837768555, Data Size: 22.28 GB
ChunkSize: 1024: Time: 57.0676474571228, Data Size: 22.28 GB
ChunkSize: 2048: Time: 56.1167368888855, Data Size: 22.28 GB
```