### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/cpu/dask-cudf/upload-anaconda.sh
+++ b/ci/cpu/dask-cudf/upload-anaconda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Adopted from https://github.com/tmcdonell/travis-scripts/blob/dfaac280ac2082cd6bcaba3217428347899f2975/update-accelerate-buildbot.sh
-export UPLOADFILE=`conda build conda-recipes -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c conda-forge -c defaults --python $PYTHON --output`
+export UPLOADFILE=`conda build conda/recipes/dask-cudf -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c defaults -c conda-forge --python=$PYTHON --output`
 
 set -e
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.