### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -37,7 +37,7 @@ $CXX --version
 
 logger "Setup new environment..."
 conda install -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
-    cudf>=0.5 \
+    cudf>=0.6 \
     dask>=0.19.0 \
     distributed>=1.23.0
 

--- a/conda/envs/dev-environment.yml
+++ b/conda/envs/dev-environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python>=3.6,<3.8
   - numba>=0.40
   - pandas>=0.23.4
-  - pyarrow=0.12.0
+  - pyarrow=0.12.1
   - notebook>=0.5.0
   - boost
   - nvstrings

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -13,12 +13,12 @@ build:
 requirements:
   build:
     - python x.x
-    - cudf 0.5*
+    - cudf 0.6*
     - dask>=0.19.0
     - distributed>=1.23.0
   run:
     - python x.x
-    - cudf 0.5*
+    - cudf 0.6*
     - dask>=0.19.0
     - distributed>=1.23.0
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cudf>=0.5
+cudf>=0.6
 dask>=0.19.0
 distributed>=1.23.0


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.