### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -36,10 +36,14 @@ $CC --version
 $CXX --version
 
 logger "Setup new environment..."
-conda install -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
-    cudf>=0.6 \
+conda install -y -q -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
+    cudf=0.6* \
+    nvstrings=0.3* \
+    pyarrow=0.12.1 \
     dask>=0.19.0 \
     distributed>=1.23.0
+
+conda list
 
 logger "Python py.test for dask-cudf..."
 cd $WORKSPACE

--- a/conda/recipes/dask-cudf/build.sh
+++ b/conda/recipes/dask-cudf/build.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python setup.py install
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -14,13 +14,13 @@ requirements:
   build:
     - python x.x
     - cudf 0.6*
-    - dask>=0.19.0
-    - distributed>=1.23.0
+    - dask >=0.19.0
+    - distributed >=1.23.0
   run:
     - python x.x
     - cudf 0.6*
-    - dask>=0.19.0
-    - distributed>=1.23.0
+    - dask >=0.19.0
+    - distributed >=1.23.0
 test:
   imports:
     - dask_cudf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cudf>=0.6
+cudf==0.6.*
 dask>=0.19.0
 distributed>=1.23.0


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.