### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/cpu/dask-cudf/upload-anaconda.sh
+++ b/ci/cpu/dask-cudf/upload-anaconda.sh
@@ -9,7 +9,7 @@ SOURCE_BRANCH=master
 
 test -e ${UPLOADFILE}
 
-LABEL_OPTION="--label main"
+LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
 
 # Restrict uploads to master branch
 if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -1,7 +1,7 @@
 # Usage:
 #   conda build -c defaults -c conda-forge .
 package:
-  name: dask_cudf
+  name: dask-cudf
   version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') }}
 
 source:


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.