### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-2019-03-18 - 0.6.0
-------------------
+dask-cudf 0.6.0 (22 Mar 2019)
+-----------------------------
 
 In this release we aligned Dask cuDF to the mainline Dask Dataframe
 codebase.  This was made possible by an alignment of cuDF to Pandas, and


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.