### PR TITLE
[REVIEW] Add cudf.DataFrame.mean = None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.6.1 - 2019-04-09
+------------------
+
+-  Add cudf.DataFrame.mean = None (#205) `Matthew Rocklin`_
+
+
 dask-cudf 0.6.0 (22 Mar 2019)
 -----------------------------
 

--- a/dask_cudf/__init__.py
+++ b/dask_cudf/__init__.py
@@ -9,6 +9,7 @@ from .core import (
 from .io import read_csv
 from . import backends
 
+import cudf
 from cudf._version import get_versions
 
 __version__ = get_versions()["version"]
@@ -22,3 +23,7 @@ __all__ = [
     "concat",
     "from_delayed",
 ]
+
+if not hasattr(cudf.DataFrame, "mean"):
+    cudf.DataFrame.mean = None
+del cudf

--- a/dask_cudf/tests/test_core.py
+++ b/dask_cudf/tests/test_core.py
@@ -327,6 +327,14 @@ def gddf(gdf):
 def test_unary_ops(func, gdf, gddf):
     p = func(gdf)
     g = func(gddf)
+
+    # Fixed in https://github.com/dask/dask/pull/4657
+    if isinstance(p, cudf.Index):
+        from packaging import version
+        if version.parse(dask.__version__) < version.parse("1.1.6"):
+            pytest.skip("dask.dataframe assert_eq index check hardcoded to "
+                        "pandas prior to 1.1.6 release")
+
     dd.assert_eq(p, g, check_names=False)
 
 


### PR DESCRIPTION
This resolves a version dispute between dask.dataframe, cudf, and
dask-cudf