### PR TITLE
Update GPUCI to enforce package version requirements (bugfix)

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -37,7 +37,10 @@ $CC --version
 $CXX --version
 
 logger "Setup new environment..."
-conda install -c 'cudf>=0.7*' 'pyarrow=0.12.1' 'dask>=1.1.5'
+conda install -c rapidsai/label/cuda$CUDA_REL -c rapidsai-nightly/label/cuda$CUDA_REL -c nvidia/label/cuda$CUDA_REL -c conda-forge \
+ 'cudf>=0.7*' \
+ 'pyarrow=0.12.1' \
+  'dask>=1.1.5'
 pip install git+https://github.com/dask/dask.git --upgrade --no-deps
 
 conda list

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -38,9 +38,9 @@ $CXX --version
 
 logger "Setup new environment..."
 conda install -c rapidsai/label/cuda$CUDA_REL -c rapidsai-nightly/label/cuda$CUDA_REL -c nvidia/label/cuda$CUDA_REL -c conda-forge \
- 'cudf>=0.7*' \
- 'pyarrow=0.12.1' \
-  'dask>=1.1.5'
+    'cudf>=0.7*' \
+    'pyarrow=0.12.1' \
+    'dask>=1.1.5'
 pip install git+https://github.com/dask/dask.git --upgrade --no-deps
 
 conda list

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -37,10 +37,7 @@ $CC --version
 $CXX --version
 
 logger "Setup new environment..."
-conda install -c rapidsai/label/cuda$CUDA_REL -c rapidsai-nightly/label/cuda$CUDA_REL -c nvidia/label/cuda$CUDA_REL -c conda-forge \
-    cudf>=0.7* \
-    pyarrow=0.12.1 \
-    dask>=1.1.5
+conda install -c 'cudf>=0.7*' 'pyarrow=0.12.1' 'dask>=1.1.5'
 pip install git+https://github.com/dask/dask.git --upgrade --no-deps
 
 conda list


### PR DESCRIPTION
**Summary of Changes**
- This PR fixes a bug in the previous GPU CI build script for dask_cudf that caused the package version requirements to be ignored
~- It also removes the explicit channel requirements, and assumes they now come from the container conda configuration~
