### PR TITLE
Use dd.read_csv to get metadata to avoid reading large files

### DIFF
--- a/dask_cudf/io/csv.py
+++ b/dask_cudf/io/csv.py
@@ -49,7 +49,7 @@ def _internal_read_csv(path, chunksize="256 MiB", **kwargs):
         return read_csv_without_chunksize(path, **kwargs)
     
     dask_reader = make_reader(cudf.read_csv, "read_csv", "CSV")
-    meta = dask_reader(filenames[0],**kwargs)._meta
+    meta = dask_reader(filenames[0], **kwargs)._meta
 
     dsk = {}
     i = 0

--- a/dask_cudf/io/csv.py
+++ b/dask_cudf/io/csv.py
@@ -47,8 +47,10 @@ def _internal_read_csv(path, chunksize="256 MiB", **kwargs):
 
     if chunksize is None:
         return read_csv_without_chunksize(path, **kwargs)
+    
+    dask_reader = make_reader(cudf.read_csv, "read_csv", "CSV")
+    meta = dask_reader(filenames[0],**kwargs)._meta
 
-    meta = cudf.read_csv(filenames[0], **kwargs)
     dsk = {}
     i = 0
     dtypes = meta.dtypes.values


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cudf/issues/144. 

- [ ] add change_log