### PR TITLE
fix inner join test -- merging does not guarantee ordering

### DIFF
--- a/dask_cudf/tests/test_join.py
+++ b/dask_cudf/tests/test_join.py
@@ -220,7 +220,12 @@ def test_indexed_join(how):
 
     d = g_left.merge(g_right, left_index=True, right_index=True, how=how)
     dg = dg_left.merge(dg_right, left_index=True, right_index=True, how=how)
-    dd.assert_eq(d, dg)
+
+    # occassionally order is not correct (possibly do to hashing in the merge)
+    d = d.sort_values('x')  # index is preserved
+    dg = dg.sort_values('x')  # index is reset -- sort_values will slow test down
+
+    dd.assert_eq(d, dg, check_index=False)
 
 
 @pytest.mark.parametrize("how", ["left", "inner"])


### PR DESCRIPTION
This PR fixes a test for joins.  From @kkraus14 

> Cudf makes no guarantee of ordering on the join

cc @raydouglass @mrocklin 