### PR TITLE
[gpuCI] Auto-merge branch-0.7 to branch-0.8 [skip ci]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-dask-cudf 0.7.0 (13 May 2019)
+dask-cudf 0.7.0 (10 May 2019)
 -----------------------------
 
 -  Remove dependency on libgdf_cffi (#228) `Keith Kraus`_


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.7` that creates a PR to keep `branch-0.8` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.