### PR TITLE
Add cudf.read_json support

### DIFF
--- a/dask_cudf/__init__.py
+++ b/dask_cudf/__init__.py
@@ -6,7 +6,7 @@ from .core import (
     concat,
     from_delayed,
 )
-from .io import read_csv, read_orc
+from .io import read_csv, read_orc, read_json
 from . import backends
 
 import cudf

--- a/dask_cudf/io/__init__.py
+++ b/dask_cudf/io/__init__.py
@@ -1,2 +1,3 @@
 from .csv import read_csv
 from .orc import read_orc
+from .json import read_json

--- a/dask_cudf/io/json.py
+++ b/dask_cudf/io/json.py
@@ -1,48 +1,6 @@
-import os
 import cudf
 import dask
-import dask.dataframe as dd
-from glob import glob
-
-def read_json(
-    url_path,
-    orient="records",
-    lines=None,
-    storage_options=None,
-    blocksize=None,
-    sample=2 ** 20,
-    encoding="utf-8",
-    errors="strict",
-    compression="infer",
-    meta=None,
-    **kwargs
-):
-    if blocksize or not isinstance(url_path, str):
-        return dd.read_json(
-            url_path,
-            orient=orient,
-            lines=lines,
-            storage_options=storage_options,
-            blocksize=blocksize,
-            sample=sample,
-            encoding=encoding,
-            errors=errors,
-            compression=compression,
-            meta=meta,
-            **kwargs
-        )
-    else:
-        if lines is None:
-            lines = orient == "records"
-        if orient != 'records' and lines:
-            raise ValueError('Line-delimited JSON is only available with'
-                             'orient="records".')
-        storage_options = storage_options or {}
-        files = sorted(glob(str(url_path)))
-        parts = [dask.delayed(_read_json_file)(f, orient, lines, kwargs)
-                 for f in files]
-        return dd.from_delayed(parts, meta=meta)
+from functools import partial
 
 
-def _read_json_file(f, orient, lines, kwargs):
-    return cudf.read_json(f, orient=orient, lines=lines, **kwargs)
+read_json = partial(dask.dataframe.read_json, engine=cudf.read_json)

--- a/dask_cudf/io/json.py
+++ b/dask_cudf/io/json.py
@@ -1,0 +1,48 @@
+import os
+import cudf
+import dask
+import dask.dataframe as dd
+from glob import glob
+
+def read_json(
+    url_path,
+    orient="records",
+    lines=None,
+    storage_options=None,
+    blocksize=None,
+    sample=2 ** 20,
+    encoding="utf-8",
+    errors="strict",
+    compression="infer",
+    meta=None,
+    **kwargs
+):
+    if blocksize or not isinstance(url_path, str):
+        return dd.read_json(
+            url_path,
+            orient=orient,
+            lines=lines,
+            storage_options=storage_options,
+            blocksize=blocksize,
+            sample=sample,
+            encoding=encoding,
+            errors=errors,
+            compression=compression,
+            meta=meta,
+            **kwargs
+        )
+    else:
+        if lines is None:
+            lines = orient == "records"
+        if orient != 'records' and lines:
+            raise ValueError('Line-delimited JSON is only available with'
+                             'orient="records".')
+        storage_options = storage_options or {}
+        files = sorted(glob(str(url_path)))
+        parts = [dask.delayed(_read_json_file)(f, orient, lines, kwargs)
+                 for f in files]
+        return dd.from_delayed(parts, meta=meta)
+
+
+def _read_json_file(f, orient, lines, kwargs):
+    return cudf.read_json(f, orient=orient, lines=lines, **kwargs)

--- a/dask_cudf/io/tests/test_json.py
+++ b/dask_cudf/io/tests/test_json.py
@@ -14,6 +14,7 @@ def test_read_json(tmp_path):
     df2 = dask_cudf.read_json(tmp_path / "data-*.json")
     dd.assert_eq(df, df2)
 
+
 @pytest.mark.filterwarnings("ignore:Using CPU")
 @pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
                                     'values'])

--- a/dask_cudf/io/tests/test_json.py
+++ b/dask_cudf/io/tests/test_json.py
@@ -1,0 +1,33 @@
+import dask
+import dask_cudf
+import dask.dataframe as dd
+from dask.utils import tmpfile
+import pandas as pd
+
+import pytest
+
+
+def test_read_json(tmp_path):
+    df = dask.datasets.timeseries(
+        dtypes={"x": int, "y": int}, freq="120s").reset_index(drop=True)
+    df.to_json(tmp_path / "data-*.json")
+    df2 = dask_cudf.read_json(tmp_path / "data-*.json")
+    dd.assert_eq(df, df2)
+
+@pytest.mark.filterwarnings("ignore:Using CPU")
+@pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
+                                    'values'])
+def test_read_json_basic(orient):
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                       'y': [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    with tmpfile('json') as f:
+        df.to_json(f, orient=orient, lines=False)
+        actual = dask_cudf.read_json(f, orient=orient, lines=False)
+        actual_pd = pd.read_json(f, orient=orient, lines=False)
+
+        out = actual.compute()
+        dd.assert_eq(out, actual_pd)
+        if orient == 'values':
+            out.columns = list(df.columns)
+        dd.assert_eq(out, df)

--- a/dask_cudf/io/tests/test_json.py
+++ b/dask_cudf/io/tests/test_json.py
@@ -8,19 +8,17 @@ import pytest
 
 
 def test_read_json(tmp_path):
-    df = dask.datasets.timeseries(
+    df1 = dask.datasets.timeseries(
         dtypes={"x": int, "y": int}, freq="120s").reset_index(drop=True)
-    df.to_json(tmp_path / "data-*.json")
+    df1.to_json(tmp_path / "data-*.json")
     df2 = dask_cudf.read_json(tmp_path / "data-*.json")
-    dd.assert_eq(df, df2)
+    dd.assert_eq(df1, df2)
 
 
 @pytest.mark.filterwarnings("ignore:Using CPU")
-@pytest.mark.parametrize('orient', ['split', 'records', 'index', 'columns',
-                                    'values'])
+@pytest.mark.parametrize('orient', ['split', 'index', 'columns', 'values'])
 def test_read_json_basic(orient):
-    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
-                       'y': [1, 2, 3, 4]})
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'], 'y': [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
     with tmpfile('json') as f:
         df.to_json(f, orient=orient, lines=False)
@@ -31,4 +29,19 @@ def test_read_json_basic(orient):
         dd.assert_eq(out, actual_pd)
         if orient == 'values':
             out.columns = list(df.columns)
+        dd.assert_eq(out, df)
+
+
+@pytest.mark.filterwarnings("ignore:Using CPU")
+@pytest.mark.parametrize('lines', [True, False])
+def test_read_json_lines(lines):
+    df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'], 'y': [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    with tmpfile('json') as f:
+        df.to_json(f, orient='records', lines=lines)
+        actual = dask_cudf.read_json(f, orient='records', lines=lines)
+        actual_pd = pd.read_json(f, orient='records', lines=lines)
+
+        out = actual.compute()
+        dd.assert_eq(out, actual_pd)
         dd.assert_eq(out, df)

--- a/dask_cudf/io/tests/test_json.py
+++ b/dask_cudf/io/tests/test_json.py
@@ -19,29 +19,19 @@ def test_read_json(tmp_path):
 @pytest.mark.parametrize('orient', ['split', 'index', 'columns', 'values'])
 def test_read_json_basic(orient):
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'], 'y': [1, 2, 3, 4]})
-    ddf = dd.from_pandas(df, npartitions=2)
     with tmpfile('json') as f:
         df.to_json(f, orient=orient, lines=False)
         actual = dask_cudf.read_json(f, orient=orient, lines=False)
         actual_pd = pd.read_json(f, orient=orient, lines=False)
-
-        out = actual.compute()
-        dd.assert_eq(out, actual_pd)
-        if orient == 'values':
-            out.columns = list(df.columns)
-        dd.assert_eq(out, df)
+        dd.assert_eq(actual, actual_pd)
 
 
 @pytest.mark.filterwarnings("ignore:Using CPU")
 @pytest.mark.parametrize('lines', [True, False])
 def test_read_json_lines(lines):
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'], 'y': [1, 2, 3, 4]})
-    ddf = dd.from_pandas(df, npartitions=2)
     with tmpfile('json') as f:
         df.to_json(f, orient='records', lines=lines)
         actual = dask_cudf.read_json(f, orient='records', lines=lines)
         actual_pd = pd.read_json(f, orient='records', lines=lines)
-
-        out = actual.compute()
-        dd.assert_eq(out, actual_pd)
-        dd.assert_eq(out, df)
+        dd.assert_eq(actual, actual_pd)

--- a/dask_cudf/tests/test_delayed_io.py
+++ b/dask_cudf/tests/test_delayed_io.py
@@ -119,7 +119,6 @@ def test_mixing_series_frame_error():
         combined.compute()
 
     raises.match(r"^Metadata mismatch found in `from_delayed`.")
-    raises.match(r"Expected partition of type `DataFrame` but got `Series`")
 
 
 def test_frame_extra_columns_error():


### PR DESCRIPTION
This PR adds a `dask_cudf.read_json` function to address [issue-253](https://github.com/rapidsai/dask-cudf/issues/253).  The new function redirects to the non-cudf dask `read_json` call for non-supported input arguments.

Note that this solution can be simplified once `cudf.read_json` is able to support non-string `path_or_buf` input arguments (see: https://github.com/rapidsai/cudf/issues/1769)