### PR TITLE
[WIP] Adding simple read_parquet function

### DIFF
--- a/dask_cudf/__init__.py
+++ b/dask_cudf/__init__.py
@@ -6,7 +6,7 @@ from .core import (
     concat,
     from_delayed,
 )
-from .io import read_csv, read_orc, read_json
+from .io import read_csv, read_orc, read_json, read_parquet
 from . import backends
 
 import cudf

--- a/dask_cudf/io/__init__.py
+++ b/dask_cudf/io/__init__.py
@@ -1,3 +1,4 @@
 from .csv import read_csv
 from .orc import read_orc
 from .json import read_json
+from .parquet import read_parquet

--- a/dask_cudf/io/parquet.py
+++ b/dask_cudf/io/parquet.py
@@ -1,0 +1,49 @@
+import os
+from glob import glob
+
+from dask.base import tokenize
+from dask.compatibility import apply
+import dask.dataframe as dd
+from dask.utils import natural_sort_key
+
+import cudf
+
+
+def read_parquet(path, **kwargs):
+    """ Read parquet files into a Dask DataFrame
+
+    This calls the ``cudf.read_parquet`` function on many parquet files.
+    See that function for additional details.
+
+    Examples
+    --------
+    >>> import dask_cudf
+    >>> df = dask_cudf.read_parquet("/path/to/dataset/")  # doctest: +SKIP
+
+    See Also
+    --------
+    cudf.read_parquet
+    """
+
+    name = "read-parquet-" + tokenize(
+        path,
+        **kwargs
+    )
+
+    paths = path
+    if isinstance(path, str):
+        paths = sorted(glob(str(path)))
+
+    # Ignore *_metadata files for now
+    paths = sorted([f for f in paths if not f.endswith('_metadata')],
+                   key=natural_sort_key)
+
+    # Use 0th file to create meta
+    meta = cudf.read_parquet(paths[0], **kwargs)
+    graph = {
+        (name, i): (apply, cudf.read_parquet, [fn], kwargs)
+        for i, fn in enumerate(paths)
+    }
+    divisions = [None] * (len(paths) + 1)
+
+    return dd.core.new_dd_object(graph, name, meta, divisions)

--- a/dask_cudf/io/tests/test_parquet.py
+++ b/dask_cudf/io/tests/test_parquet.py
@@ -1,0 +1,50 @@
+import os
+
+import dask_cudf
+import pandas as pd
+import dask.dataframe as dd
+from dask.dataframe.utils import assert_eq
+from dask.utils import natural_sort_key
+import cudf
+
+import pytest
+
+
+nrows = 40
+npartitions = 15
+df = pd.DataFrame({'x': [i * 7 % 5 for i in range(nrows)],  # Not sorted
+                   'y': [i * 2.5 for i in range(nrows)]})   # Sorted
+ddf = dd.from_pandas(df, npartitions=npartitions)
+
+
+def test_roundtrip_from_dask(tmpdir):
+    tmpdir = str(tmpdir)
+    ddf.to_parquet(tmpdir, engine='pyarrow')
+    files = sorted([os.path.join(tmpdir, f)
+                   for f in os.listdir(tmpdir)
+                   if not f.endswith('_metadata')],
+                   key=natural_sort_key)
+
+    # Read list of parquet files
+    ddf2 = dask_cudf.read_parquet(files)
+    assert_eq(ddf, ddf2, check_divisions=False)
+
+    # Specify columns=['x']
+    ddf2 = dask_cudf.read_parquet(files, columns=['x'])
+    assert_eq(ddf[['x']], ddf2, check_divisions=False)
+
+    # Specify columns='y'
+    ddf2 = dask_cudf.read_parquet(files, columns='y')
+    assert_eq(ddf[['y']], ddf2, check_divisions=False)
+
+    # Read parquet-dataset directory
+    # dask_cudf.read_parquet will ignore *_metadata files
+    ddf2 = dask_cudf.read_parquet(os.path.join(tmpdir, '*'))
+    assert_eq(ddf, ddf2, check_divisions=False)
+
+
+def test_roundtrip_from_pandas(tmpdir):
+    fn = str(tmpdir.join('test.parquet'))
+    df.to_parquet(fn)
+    ddf2 = dask_cudf.read_parquet(fn)
+    assert_eq(df, ddf2)


### PR DESCRIPTION
The full-featured parquet API in Dask is still under construction (refactoring, cleanup, etc).  In the meantime, I am adding a very simple `dask_cudf.read_parquet()` implementation.  A `to_parquet` function can also be added if it is useful.

@mrocklin @randerzander Please do let me know if any other basic functionality is a high priority. I am happy to improve/iterate on this.