### PR TITLE
Address groupby test failures

### DIFF
--- a/dask_cudf/tests/test_groupby.py
+++ b/dask_cudf/tests/test_groupby.py
@@ -33,15 +33,19 @@ def test_groupby(func, check_dtype):
 
     ddf = dask_cudf.from_cudf(gdf, npartitions=5)
 
-    a = func(gdf).to_pandas()
-    b = func(ddf).compute().to_pandas()
+    a = pd.DataFrame(func(gdf).to_pandas())
+    b = pd.DataFrame(func(ddf).compute().to_pandas())
 
     a.index.name = None
     a.name = None
     b.index.name = None
     b.name = None
 
-    dd.assert_eq(a, b, check_dtype=check_dtype)
+    dd.assert_eq(
+        a,
+        b,
+        check_dtype=check_dtype
+    )
 
 
 @pytest.mark.xfail(reason="cudf issues")
@@ -93,7 +97,7 @@ def test_groupby_multi_column(func):
 
     ddf = dask_cudf.from_cudf(gdf, npartitions=5)
 
-    a = func(gdf).to_pandas()
-    b = func(ddf).compute().to_pandas()
+    a = pd.DataFrame(func(gdf).to_pandas())
+    b = pd.DataFrame(func(ddf).compute().to_pandas())
 
     dd.assert_eq(a, b)

--- a/dask_cudf/tests/test_groupby.py
+++ b/dask_cudf/tests/test_groupby.py
@@ -8,21 +8,23 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "func",
+    "func,check_dtype",
     [
-        lambda df: df.groupby("x").sum(),
-        lambda df: df.groupby("x").mean(),
-        lambda df: df.groupby("x").count(),
-        lambda df: df.groupby("x").min(),
-        lambda df: df.groupby("x").max(),
-        lambda df: df.groupby("x").y.sum(),
-        lambda df: df.groupby("x").agg({"y": "max"}),
+        (lambda df: df.groupby("x").sum(), True),
+        (lambda df: df.groupby("x").mean(), True),
+        (lambda df: df.groupby("x").count(), False),
+        (lambda df: df.groupby("x").min(), True),
+        (lambda df: df.groupby("x").max(), True),
+        (lambda df: df.groupby("x").y.sum(), True),
+        (lambda df: df.groupby("x").agg({"y": "max"}), True),
         pytest.param(
-            lambda df: df.groupby("x").y.agg(["sum", "max"]), marks=pytest.mark.skip
+            lambda df: df.groupby("x").y.agg(["sum", "max"]),
+            True,
+            marks=pytest.mark.skip
         )
     ],
 )
-def test_groupby(func):
+def test_groupby(func, check_dtype):
     pdf = pd.DataFrame(
         {"x": np.random.randint(0, 5, size=10000), "y": np.random.normal(size=10000)}
     )
@@ -39,7 +41,7 @@ def test_groupby(func):
     b.index.name = None
     b.name = None
 
-    dd.assert_eq(a, b)
+    dd.assert_eq(a, b, check_dtype=check_dtype)
 
 
 @pytest.mark.xfail(reason="cudf issues")


### PR DESCRIPTION
Modifications to tests to "fix" the following groupby failures:

1. `groupby.count()` returns a column with `int64` dtype while Pandas returns `int32`
2. cuDF sometimes returns a DataFrame instead of a Series after groupby